### PR TITLE
Harden JWT auth sample cookie and token handling

### DIFF
--- a/server/src/MyContext.ts
+++ b/server/src/MyContext.ts
@@ -3,5 +3,5 @@ import { Request, Response } from 'express'
 export interface MyContext {
   req: Request
   res: Response
-  payload?: { userId: string }
+  payload?: { userId: number }
 }

--- a/server/src/UserResolver.ts
+++ b/server/src/UserResolver.ts
@@ -1,13 +1,12 @@
-import { Int, Resolver, Query, Mutation, Arg, ObjectType, Field, Ctx, UseMiddleware } from 'type-graphql'
+import { Resolver, Query, Mutation, Arg, ObjectType, Field, Ctx, UseMiddleware } from 'type-graphql'
 import { isAuth } from './isAuthMiddleware'
-import { createRefreshToken, createAccessToken } from './auth'
+import { createRefreshToken, createAccessToken, verifyAccessToken } from './auth'
 import { MyContext } from './MyContext'
 
 import { hash, compare } from 'bcryptjs'
 import { User } from './entity/User'
-import { sendRefreshToken } from './sendRefreshToken'
+import { sendRefreshToken, clearRefreshToken } from './sendRefreshToken'
 import { getConnection } from 'typeorm'
-import { verify } from 'jsonwebtoken'
 
 @ObjectType()
 class LoginResponse {
@@ -35,6 +34,7 @@ export class UserResolver {
   }
 
   @Query(() => [User])
+  @UseMiddleware(isAuth)
   users () {
     return User.find()
   }
@@ -51,8 +51,8 @@ export class UserResolver {
     }
 
     try {
-      const token = authorization?.split(' ')[1]
-      const payload: any = verify(token, process.env.ACCESS_TOKEN_SECRET!)
+      const token = authorization.split(' ')[1]
+      const payload = verifyAccessToken(token)
       return User.findOne(payload.userId)
     } catch (err) {
       console.error(err)
@@ -64,16 +64,21 @@ export class UserResolver {
   async logout (
     @Ctx() { res }: MyContext
   ) {
-    sendRefreshToken(res, '')
+    clearRefreshToken(res)
 
     return true
   }
 
   @Mutation(() => Boolean)
-  async revokeRefreshTokenForUser (
-    @Arg('userId', () => Int) userId: number
+  @UseMiddleware(isAuth)
+  async revokeMyRefreshTokens (
+    @Ctx() { payload }: MyContext
   ) {
-    await getConnection().getRepository(User).increment({ id: userId }, 'tokenVersion', 1)
+    if (!payload?.userId) {
+      throw new Error('not authenticated')
+    }
+
+    await getConnection().getRepository(User).increment({ id: payload.userId }, 'tokenVersion', 1)
 
     return true
   }

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -1,15 +1,84 @@
 import { User } from './entity/User'
-import { sign } from 'jsonwebtoken'
+import { sign, verify } from 'jsonwebtoken'
+
+export const JWT_ISSUER = 'jwt-auth-sample'
+export const ACCESS_TOKEN_AUDIENCE = 'jwt-auth-sample-access'
+export const REFRESH_TOKEN_AUDIENCE = 'jwt-auth-sample-refresh'
+export const JWT_ALGORITHM = 'HS256'
+
+export interface AccessTokenPayload {
+  userId: number
+}
+
+export interface RefreshTokenPayload extends AccessTokenPayload {
+  tokenVersion: number
+}
+
+const isObjectPayload = (payload: unknown): payload is Record<string, unknown> => {
+  return typeof payload === 'object' && payload !== null && !Array.isArray(payload)
+}
+
+const verifyTokenPayload = (token: string, secret: string, audience: string) => {
+  const payload = verify(token, secret, {
+    issuer: JWT_ISSUER,
+    audience,
+    algorithms: [JWT_ALGORITHM]
+  })
+
+  if (!isObjectPayload(payload)) {
+    throw new Error('invalid token payload')
+  }
+
+  return payload
+}
+
+const readUserId = (payload: Record<string, unknown>) => {
+  const userId = payload.userId
+
+  if (typeof userId !== 'number') {
+    throw new Error('invalid token payload')
+  }
+
+  return userId
+}
 
 export const createAccessToken = (user: User) => {
   return sign({ userId: user.id }, process.env.ACCESS_TOKEN_SECRET!, {
-    expiresIn: '15m'
+    expiresIn: '15m',
+    issuer: JWT_ISSUER,
+    audience: ACCESS_TOKEN_AUDIENCE,
+    algorithm: JWT_ALGORITHM
   })
 }
 
 export const createRefreshToken = (user: User) => {
   return sign(
     { userId: user.id, tokenVersion: user.tokenVersion }, process.env.REFRESH_TOKEN_SECRET!, {
-      expiresIn: '7d'
+      expiresIn: '7d',
+      issuer: JWT_ISSUER,
+      audience: REFRESH_TOKEN_AUDIENCE,
+      algorithm: JWT_ALGORITHM
     })
+}
+
+export const verifyAccessToken = (token: string): AccessTokenPayload => {
+  const payload = verifyTokenPayload(token, process.env.ACCESS_TOKEN_SECRET!, ACCESS_TOKEN_AUDIENCE)
+
+  return {
+    userId: readUserId(payload)
+  }
+}
+
+export const verifyRefreshToken = (token: string): RefreshTokenPayload => {
+  const payload = verifyTokenPayload(token, process.env.REFRESH_TOKEN_SECRET!, REFRESH_TOKEN_AUDIENCE)
+  const tokenVersion = payload.tokenVersion
+
+  if (typeof tokenVersion !== 'number') {
+    throw new Error('invalid token payload')
+  }
+
+  return {
+    userId: readUserId(payload),
+    tokenVersion
+  }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,3 @@
-// import { User } from './entity/User'
-// import { verify } from 'jsonwebtoken'
 import 'dotenv/config'
 import 'reflect-metadata'
 import express from 'express'
@@ -8,69 +6,65 @@ import { buildSchema } from 'type-graphql'
 import { UserResolver } from './UserResolver'
 import { createConnection } from 'typeorm'
 import cookieParser from 'cookie-parser'
-// import { createAccessToken, createRefreshToken } from './auth'
-// import { sendRefreshToken } from './sendRefreshToken'
 import cors from 'cors'
-import fetch from 'node-fetch';
+import fetch from 'node-fetch'
+import { sendRefreshToken } from './sendRefreshToken'
+
+const DEFAULT_CLIENT_ORIGIN = 'http://localhost:3000'
+const configuredOrigins = (process.env.CORS_ORIGIN || DEFAULT_CLIENT_ORIGIN)
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean)
+const allowedOrigins = configuredOrigins.length > 0 ? configuredOrigins : [DEFAULT_CLIENT_ORIGIN]
+const corsOrigin = allowedOrigins.length === 1 ? allowedOrigins[0] : allowedOrigins
+
+const isAllowedOrigin = (origin: string | string[] | undefined): boolean => {
+  if (!origin) return true
+  if (Array.isArray(origin)) return false
+  return allowedOrigins.includes(origin)
+}
 
 (async () => {
   const app = express()
   app.use(cors({
-    origin: 'http://localhost:3000',
+    origin: corsOrigin,
     credentials: true
   }))
   app.use(cookieParser())
   app.get('/', (_req, res) => res.send('hello'))
   app.post('/refresh_token', async (req, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) {
+      return res.status(403).send({ ok: false, accessToken: '' })
+    }
+
     const token = req.cookies.jid
     if (!token) {
-      console.log('token is not found')
       return res.send({ ok: false, accessToken: '' })
     }
-    // refresh tokenでaccess tokenを更新する
+
     try {
-      // headersにrefresh_tokenを入れてエンドポイントにリクエストを送る。
+      // refresh tokenでaccess tokenを更新する
       const response = await fetch('http://localhost:8000/api/refresh_token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', refreshToken: token }
       })
 
+      if (response.status !== 200) {
+        // Keep the response body shape stable for existing TokenRefreshLink/client handling.
+        return res.status(401).send({ ok: false, accessToken: '' })
+      }
+
       const json = await response.json()
-      if (response.status !== 200) throw new Error('response error')
 
-      console.log('access_token: ', json.access_token)
-      console.log('refresh_token: ', json.refresh_token)
+      if (!json.access_token || !json.refresh_token) {
+        return res.status(401).send({ ok: false, accessToken: '' })
+      }
 
-      res.cookie('jid', json.refresh_token, {
-        httpOnly: true
-        // domain: '.a-yo.jp'
-        // path: '/refresh_token'
-      })
+      sendRefreshToken(res, json.refresh_token)
       return res.send({ ok: true, accessToken: json.access_token })
-    } catch (error) {
-      return res.send({ ok: false, accessToken: '' })
+    } catch {
+      return res.status(401).send({ ok: false, accessToken: '' })
     }
-
-    // let payload: any = null
-    // try {
-    //   payload = verify(token, process.env.REFRESH_TOKEN_SECRET!)
-    // } catch (err) {
-    //   console.error(err)
-    //   return res.send({ ok: false, accessToken: '' })
-    // }
-    // const user = await User.findOne({ id: payload.userId })
-
-    // if (!user) {
-    //   console.log('user is not found')
-    //   return res.send({ ok: false, accessToken: '' })
-    // }
-
-    // if (user.tokenVersion !== payload.tokenVersion) {
-    //   console.log('tokenVersion is invalid')
-    //   return res.send({ ok: false, accessToken: '' })
-    // }
-
-    // sendRefreshToken(res, createRefreshToken(user))
   })
   await createConnection()
 

--- a/server/src/isAuthMiddleware.ts
+++ b/server/src/isAuthMiddleware.ts
@@ -1,6 +1,6 @@
 import { MyContext } from './MyContext'
 import { MiddlewareFn } from 'type-graphql'
-import { verify } from 'jsonwebtoken'
+import { verifyAccessToken } from './auth'
 
 export const isAuth: MiddlewareFn<MyContext> = ({ context }, next) => {
   const authorization = context.req.headers.authorization
@@ -10,9 +10,8 @@ export const isAuth: MiddlewareFn<MyContext> = ({ context }, next) => {
   }
 
   try {
-    const token = authorization?.split(' ')[1]
-    const payload = verify(token, process.env.ACCESS_TOKEN_SECRET!)
-    context.payload = payload as any
+    const token = authorization.split(' ')[1]
+    context.payload = verifyAccessToken(token)
   } catch (err) {
     console.error(err)
     throw new Error('not authenticated')

--- a/server/src/sendRefreshToken.ts
+++ b/server/src/sendRefreshToken.ts
@@ -1,8 +1,25 @@
 import { Response } from 'express'
+
+const REFRESH_TOKEN_COOKIE_NAME = 'jid'
+const REFRESH_TOKEN_COOKIE_PATH = '/refresh_token'
+const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000
+
+const refreshTokenCookieBaseOptions = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax',
+  path: REFRESH_TOKEN_COOKIE_PATH
+} as const
+
+const refreshTokenCookieOptions = {
+  ...refreshTokenCookieBaseOptions,
+  maxAge: REFRESH_TOKEN_MAX_AGE
+}
+
 export const sendRefreshToken = (res: Response, token: string) => {
-  res.cookie('jid', token, {
-    httpOnly: true
-    // domain: '.a-yo.jp'
-    // path: '/refresh_token'
-  })
+  res.cookie(REFRESH_TOKEN_COOKIE_NAME, token, refreshTokenCookieOptions)
+}
+
+export const clearRefreshToken = (res: Response) => {
+  res.clearCookie(REFRESH_TOKEN_COOKIE_NAME, refreshTokenCookieBaseOptions)
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,6 @@ export const App: React.FC = () => {
     }).then(async x => {
       const { accessToken } = await x.json()
       setAccessToken(accessToken)
-      console.log(accessToken)
       setLoading(false)
     })
   }, [])

--- a/web/src/generated/graphql.tsx
+++ b/web/src/generated/graphql.tsx
@@ -20,15 +20,11 @@ export type LoginResponse = {
 export type Mutation = {
    __typename?: 'Mutation',
   logout: Scalars['Boolean'],
-  revokeRefreshTokenForUser: Scalars['Boolean'],
+  revokeMyRefreshTokens: Scalars['Boolean'],
   login: LoginResponse,
   resister: Scalars['Boolean'],
 };
 
-
-export type MutationRevokeRefreshTokenForUserArgs = {
-  userId: Scalars['Int']
-};
 
 
 export type MutationLoginArgs = {

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -20,11 +20,11 @@ const requestLink = new ApolloLink((operation, forward) =>
     Promise.resolve(operation)
       .then((operation) => {
         const accessToken = getAccessToken()
-        operation.setContext({
-          headers: {
-            authorization: `bearer ${accessToken}`
-          }
-        })
+        const headers = accessToken
+          ? { authorization: `Bearer ${accessToken}` }
+          : {}
+
+        operation.setContext({ headers })
       })
       .then(() => {
         handle = forward(operation).subscribe({
@@ -72,15 +72,6 @@ const client = new ApolloClient({
       handleFetch: accessToken => {
         setAccessToken(accessToken)
       },
-      // handleResponse: (operation, accessTokenField) => response => {
-      //   // here you can parse response, handle errors, prepare returned token to
-      //   // further operations
-
-      //   // returned object should be like this:
-      //   // {
-      //   //    access_token: 'token string here'
-      //   // }
-      // },
       handleError: err => {
         // full control over handling token fetch Error
         console.warn('Your refresh token is invalid. Try to relogin')

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -15,8 +15,6 @@ export const Login: React.FC<RouteComponentProps> = ({ history }) => {
     <form onSubmit={async e => {
       e.preventDefault()
 
-      console.log('form submitted')
-      console.log(email, password)
       const response = await login({
         variables: {
           email,
@@ -34,8 +32,6 @@ export const Login: React.FC<RouteComponentProps> = ({ history }) => {
           })
         }
       })
-      console.log(response)
-
       if (response && response.data) {
         setAccessToken(response.data.login.accessToken)
       }

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -14,15 +14,12 @@ export const Register: React.FC<RouteComponentProps> = ({ history }) => {
     <form onSubmit={async e => {
       e.preventDefault()
 
-      console.log('form submitted')
-      console.log(email, password)
-      const response = await register({
+      await register({
         variables: {
           email,
           password
         }
       })
-      console.log(response)
       history.push('/')
     }}>
       <div>


### PR DESCRIPTION
## Summary
- Hardened the `jid` refresh-token cookie with HttpOnly, Secure-in-production, SameSite=Lax, `/refresh_token` path scoping, and a 7-day max age.
- Added a matching cookie clear helper and use it on logout.
- Removed token/credential-bearing console logs from refresh and frontend auth flows.
- Added `CORS_ORIGIN`-driven allowed origins plus explicit Origin validation for `POST /refresh_token`.
- Protected `users()` with auth and replaced arbitrary user token revocation with authenticated `revokeMyRefreshTokens`.
- Omit the frontend Authorization header when no access token exists and use canonical `Bearer` casing.
- Added JWT issuer, audience, and HS256 algorithm options to local token signing/verification.

## Files changed
- `server/src/sendRefreshToken.ts`
- `server/src/index.ts`
- `server/src/auth.ts`
- `server/src/isAuthMiddleware.ts`
- `server/src/UserResolver.ts`
- `server/src/MyContext.ts`
- `web/src/index.tsx`
- `web/src/App.tsx`
- `web/src/pages/Login.tsx`
- `web/src/pages/Register.tsx`
- `web/src/generated/graphql.tsx`

## Manual verification
- `yarn install --frozen-lockfile`
- `cd server && yarn tsc --noEmit`
- `cd server && yarn eslint src --ext .ts,.tsx`
- `cd web && yarn build` currently fails on Node.js v24 with the existing CRA/webpack OpenSSL error (`ERR_OSSL_EVP_UNSUPPORTED`).
- `cd web && NODE_OPTIONS=--openssl-legacy-provider yarn build` succeeds.

## Out of scope
- Full refresh token rotation / reuse detection / DB schema changes.
- Dependency upgrades.
- BFF migration.
