### PR TITLE
Implement refresh token rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # jwt-auth-sample
 
-Ben Awad 氏の JWT 認証サンプルを参考にした、React SPA + GraphQL API の認証サンプルです。
+A React SPA + GraphQL API authentication sample based on Ben Awad's JWT auth example.
 
-参考実装: https://github.com/benawad/jwt-auth-example
+Reference implementation: https://github.com/benawad/jwt-auth-example
 
-## 改善内容
+## Improvements
 
-このサンプルでは、元の構成を保ったまま認証まわりを少し堅牢にしています。
+This version keeps the original architecture while hardening the authentication flow.
 
-- アクセストークンは React のメモリ上で管理
-- リフレッシュトークンは HttpOnly Cookie で管理
-- `/refresh_token` でアクセストークンを再発行
-- リフレッシュトークンに `jti` を付与し、DB 上のセッションと対応付け
-- リフレッシュごとにトークンをローテーションし、再利用を検知した場合は同じトークンファミリーを失効
-- Cookie 名に `__Host-` プレフィックスを使い、Cookie の上書きリスクを低減
-- `/refresh_token` で Origin / Referer / Fetch Metadata を確認し、CSRF リスクを低減
-- ログにトークンやスタックトレースを出さないようにエラー出力をサニタイズ
-- GraphQL ミューテーション向け CSRF トークン検証の土台を追加
+- Stores the access token in React memory
+- Stores the refresh token in an HttpOnly cookie
+- Reissues access tokens through `/refresh_token`
+- Adds a `jti` claim to refresh tokens and maps them to database-backed sessions
+- Rotates refresh tokens on every refresh and revokes the token family when reuse is detected
+- Uses the `__Host-` cookie prefix to reduce cookie overwrite risk
+- Checks Origin, Referer, and Fetch Metadata on `/refresh_token` to reduce CSRF risk
+- Sanitizes error logging to avoid printing tokens or stack traces
+- Adds groundwork for CSRF token validation on GraphQL mutations

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
 # jwt-auth-sample
 
 ## このサンプルの実装　https://github.com/benawad/jwt-auth-example
-
-## Refresh token rotation notes
-
-This sample stores the access token in React memory and stores the refresh token in an HttpOnly `__Host-jid` cookie. Refresh tokens are rotated locally by the server and persisted as hashed `RefreshTokenSession` rows keyed by `jti` and token family.
-
-Migration notes:
-
-- Existing pre-rotation `jid` cookies and refresh tokens without `jti` cannot be mapped to a DB session. Users with those cookies must log in again.
-- The repository currently uses TypeORM `synchronize: true`, so the new refresh-token table is created from the entity in development. Production deployments should replace this with an additive migration before disabling synchronization.
-- `/refresh_token` requires a matching `Origin` or `Referer` header. Missing origin headers are allowed only outside production when `ALLOW_MISSING_ORIGIN_IN_DEV=true`.
-- `Sec-Fetch-Site: cross-site` state-changing requests are rejected unless the origin is explicitly listed in `FETCH_METADATA_CROSS_SITE_ALLOW_ORIGINS`.
-- CSRF token cookie/header helpers are present for GraphQL mutations, but mutation enforcement is intentionally left for a follow-up change.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # jwt-auth-sample
 
 ## このサンプルの実装　https://github.com/benawad/jwt-auth-example
+
+## Refresh token rotation notes
+
+This sample stores the access token in React memory and stores the refresh token in an HttpOnly `__Host-jid` cookie. Refresh tokens are rotated locally by the server and persisted as hashed `RefreshTokenSession` rows keyed by `jti` and token family.
+
+Migration notes:
+
+- Existing pre-rotation `jid` cookies and refresh tokens without `jti` cannot be mapped to a DB session. Users with those cookies must log in again.
+- The repository currently uses TypeORM `synchronize: true`, so the new refresh-token table is created from the entity in development. Production deployments should replace this with an additive migration before disabling synchronization.
+- `/refresh_token` requires a matching `Origin` or `Referer` header. Missing origin headers are allowed only outside production when `ALLOW_MISSING_ORIGIN_IN_DEV=true`.
+- `Sec-Fetch-Site: cross-site` state-changing requests are rejected unless the origin is explicitly listed in `FETCH_METADATA_CROSS_SITE_ALLOW_ORIGINS`.
+- CSRF token cookie/header helpers are present for GraphQL mutations, but mutation enforcement is intentionally left for a follow-up change.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # jwt-auth-sample
 
-## このサンプルの実装　https://github.com/benawad/jwt-auth-example
+Ben Awad 氏の JWT 認証サンプルを参考にした、React SPA + GraphQL API の認証サンプルです。
+
+参考実装: https://github.com/benawad/jwt-auth-example
+
+## 改善内容
+
+このサンプルでは、元の構成を保ったまま認証まわりを少し堅牢にしています。
+
+- アクセストークンは React のメモリ上で管理
+- リフレッシュトークンは HttpOnly Cookie で管理
+- `/refresh_token` でアクセストークンを再発行
+- リフレッシュトークンに `jti` を付与し、DB 上のセッションと対応付け
+- リフレッシュごとにトークンをローテーションし、再利用を検知した場合は同じトークンファミリーを失効
+- Cookie 名に `__Host-` プレフィックスを使い、Cookie の上書きリスクを低減
+- `/refresh_token` で Origin / Referer / Fetch Metadata を確認し、CSRF リスクを低減
+- ログにトークンやスタックトレースを出さないようにエラー出力をサニタイズ
+- GraphQL ミューテーション向け CSRF トークン検証の土台を追加

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "start": "nodemon --exec ts-node src/index.ts",
+    "test": "ts-node test/requestSecurity.test.ts",
     "lint-f": "eslint --fix src --ext .ts,.tsx"
   }
 }

--- a/server/src/UserResolver.ts
+++ b/server/src/UserResolver.ts
@@ -1,12 +1,19 @@
 import { Resolver, Query, Mutation, Arg, ObjectType, Field, Ctx, UseMiddleware } from 'type-graphql'
 import { isAuth } from './isAuthMiddleware'
-import { createRefreshToken, createAccessToken, verifyAccessToken } from './auth'
+import { createAccessToken, verifyAccessToken } from './auth'
 import { MyContext } from './MyContext'
 
 import { hash, compare } from 'bcryptjs'
 import { User } from './entity/User'
-import { sendRefreshToken, clearRefreshToken } from './sendRefreshToken'
+import { sendRefreshToken, clearRefreshToken, REFRESH_TOKEN_COOKIE_NAME } from './sendRefreshToken'
 import { getConnection } from 'typeorm'
+import { clearCsrfToken, sendCsrfToken } from './csrf'
+import { logSanitizedError } from './logger'
+import {
+  issueRefreshTokenSession,
+  revokeAllRefreshTokenSessionsForUser,
+  revokeRefreshTokenFamilyForToken
+} from './refreshTokenSession'
 
 @ObjectType()
 class LoginResponse {
@@ -29,7 +36,6 @@ export class UserResolver {
   bye (
     @Ctx() { payload }: MyContext
   ) {
-    console.log(payload)
     return `your user id is: ${payload?.userId}`
   }
 
@@ -46,7 +52,6 @@ export class UserResolver {
     const authorization = context.req.headers.authorization
 
     if (!authorization) {
-      console.log('me does not have authorization')
       return null
     }
 
@@ -55,16 +60,23 @@ export class UserResolver {
       const payload = verifyAccessToken(token)
       return User.findOne(payload.userId)
     } catch (err) {
-      console.error(err)
+      logSanitizedError('me query authentication failed', err)
       return null
     }
   }
 
   @Mutation(() => Boolean)
   async logout (
-    @Ctx() { res }: MyContext
+    @Ctx() { req, res }: MyContext
   ) {
+    const token = req.cookies[REFRESH_TOKEN_COOKIE_NAME]
+
+    if (token) {
+      await revokeRefreshTokenFamilyForToken(token)
+    }
+
     clearRefreshToken(res)
+    clearCsrfToken(res)
 
     return true
   }
@@ -79,6 +91,7 @@ export class UserResolver {
     }
 
     await getConnection().getRepository(User).increment({ id: payload.userId }, 'tokenVersion', 1)
+    await revokeAllRefreshTokenSessionsForUser(payload.userId)
 
     return true
   }
@@ -101,7 +114,10 @@ export class UserResolver {
       throw new Error('bad password')
     }
 
-    sendRefreshToken(res, createRefreshToken(user))
+    const refreshToken = await issueRefreshTokenSession(user)
+
+    sendRefreshToken(res, refreshToken.token)
+    sendCsrfToken(res)
 
     return {
       accessToken: createAccessToken(user),
@@ -119,7 +135,7 @@ export class UserResolver {
         password: hashedPassword
       })
     } catch (err) {
-      console.error(err)
+      logSanitizedError('register failed', err)
       return false
     }
 

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -5,6 +5,7 @@ export const JWT_ISSUER = 'jwt-auth-sample'
 export const ACCESS_TOKEN_AUDIENCE = 'jwt-auth-sample-access'
 export const REFRESH_TOKEN_AUDIENCE = 'jwt-auth-sample-refresh'
 export const JWT_ALGORITHM = 'HS256'
+export const REFRESH_TOKEN_EXPIRES_IN_MS = 7 * 24 * 60 * 60 * 1000
 
 export interface AccessTokenPayload {
   userId: number
@@ -12,6 +13,7 @@ export interface AccessTokenPayload {
 
 export interface RefreshTokenPayload extends AccessTokenPayload {
   tokenVersion: number
+  jti: string
 }
 
 const isObjectPayload = (payload: unknown): payload is Record<string, unknown> => {
@@ -51,9 +53,9 @@ export const createAccessToken = (user: User) => {
   })
 }
 
-export const createRefreshToken = (user: User) => {
+export const createRefreshToken = (user: User, jti: string) => {
   return sign(
-    { userId: user.id, tokenVersion: user.tokenVersion }, process.env.REFRESH_TOKEN_SECRET!, {
+    { userId: user.id, tokenVersion: user.tokenVersion, jti }, process.env.REFRESH_TOKEN_SECRET!, {
       expiresIn: '7d',
       issuer: JWT_ISSUER,
       audience: REFRESH_TOKEN_AUDIENCE,
@@ -72,13 +74,15 @@ export const verifyAccessToken = (token: string): AccessTokenPayload => {
 export const verifyRefreshToken = (token: string): RefreshTokenPayload => {
   const payload = verifyTokenPayload(token, process.env.REFRESH_TOKEN_SECRET!, REFRESH_TOKEN_AUDIENCE)
   const tokenVersion = payload.tokenVersion
+  const jti = payload.jti
 
-  if (typeof tokenVersion !== 'number') {
+  if (typeof tokenVersion !== 'number' || typeof jti !== 'string') {
     throw new Error('invalid token payload')
   }
 
   return {
     userId: readUserId(payload),
-    tokenVersion
+    tokenVersion,
+    jti
   }
 }

--- a/server/src/csrf.ts
+++ b/server/src/csrf.ts
@@ -1,0 +1,51 @@
+import { NextFunction, Request, Response } from 'express'
+import { randomBytes } from 'crypto'
+
+export const CSRF_COOKIE_NAME = '__Host-csrf'
+export const CSRF_HEADER_NAME = 'x-csrf-token'
+const CSRF_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000
+
+const csrfCookieBaseOptions = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax',
+  path: '/'
+} as const
+
+const csrfCookieOptions = {
+  ...csrfCookieBaseOptions,
+  maxAge: CSRF_TOKEN_MAX_AGE
+}
+
+export const createCsrfToken = () => randomBytes(32).toString('hex')
+
+export const sendCsrfToken = (res: Response, token = createCsrfToken()) => {
+  res.cookie(CSRF_COOKIE_NAME, token, csrfCookieOptions)
+  res.setHeader('X-CSRF-Token', token)
+  return token
+}
+
+export const clearCsrfToken = (res: Response) => {
+  res.clearCookie(CSRF_COOKIE_NAME, csrfCookieBaseOptions)
+}
+
+const readHeader = (req: Request): string | undefined => {
+  const header = req.headers[CSRF_HEADER_NAME]
+
+  if (!header || Array.isArray(header)) {
+    return undefined
+  }
+
+  return header
+}
+
+export const csrfProtection = (req: Request, res: Response, next: NextFunction) => {
+  const cookieToken = req.cookies[CSRF_COOKIE_NAME]
+  const headerToken = readHeader(req)
+
+  if (!cookieToken || !headerToken || cookieToken !== headerToken) {
+    return res.status(403).send({ ok: false })
+  }
+
+  return next()
+}

--- a/server/src/entity/RefreshTokenSession.ts
+++ b/server/src/entity/RefreshTokenSession.ts
@@ -1,0 +1,33 @@
+import { BaseEntity, Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+
+@Entity('refresh_token_sessions')
+@Index(['userId'])
+@Index(['tokenFamilyId'])
+export class RefreshTokenSession extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column('int')
+  userId: number
+
+  @Column('text', { unique: true })
+  jti: string
+
+  @Column('text', { unique: true })
+  tokenHash: string
+
+  @Column('text')
+  tokenFamilyId: string
+
+  @Column('timestamp with time zone', { nullable: true })
+  revokedAt: Date | null
+
+  @Column('uuid', { nullable: true })
+  replacedByTokenId: string | null
+
+  @Column('timestamp with time zone')
+  expiresAt: Date
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,62 +7,48 @@ import { UserResolver } from './UserResolver'
 import { createConnection } from 'typeorm'
 import cookieParser from 'cookie-parser'
 import cors from 'cors'
-import fetch from 'node-fetch'
-import { sendRefreshToken } from './sendRefreshToken'
-
-const DEFAULT_CLIENT_ORIGIN = 'http://localhost:3000'
-const configuredOrigins = (process.env.CORS_ORIGIN || DEFAULT_CLIENT_ORIGIN)
-  .split(',')
-  .map(origin => origin.trim())
-  .filter(Boolean)
-const allowedOrigins = configuredOrigins.length > 0 ? configuredOrigins : [DEFAULT_CLIENT_ORIGIN]
-const corsOrigin = allowedOrigins.length === 1 ? allowedOrigins[0] : allowedOrigins
-
-const isAllowedOrigin = (origin: string | string[] | undefined): boolean => {
-  if (!origin) return true
-  if (Array.isArray(origin)) return false
-  return allowedOrigins.includes(origin)
-}
+import { createAccessToken } from './auth'
+import { clearRefreshToken, REFRESH_TOKEN_COOKIE_NAME, sendRefreshToken } from './sendRefreshToken'
+import { rotateRefreshToken } from './refreshTokenSession'
+import { corsOrigin, validateStateChangingRequestOrigin } from './requestSecurity'
+import { sendCsrfToken } from './csrf'
+import { logSanitizedError } from './logger'
 
 (async () => {
   const app = express()
   app.use(cors({
     origin: corsOrigin,
-    credentials: true
+    credentials: true,
+    exposedHeaders: ['X-CSRF-Token']
   }))
   app.use(cookieParser())
   app.get('/', (_req, res) => res.send('hello'))
   app.post('/refresh_token', async (req, res) => {
-    if (!isAllowedOrigin(req.headers.origin)) {
+    const requestOriginError = validateStateChangingRequestOrigin(req)
+
+    if (requestOriginError) {
       return res.status(403).send({ ok: false, accessToken: '' })
     }
 
-    const token = req.cookies.jid
+    const token = req.cookies[REFRESH_TOKEN_COOKIE_NAME]
     if (!token) {
       return res.send({ ok: false, accessToken: '' })
     }
 
     try {
-      // refresh tokenでaccess tokenを更新する
-      const response = await fetch('http://localhost:8000/api/refresh_token', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', refreshToken: token }
-      })
+      const rotatedToken = await rotateRefreshToken(token)
 
-      if (response.status !== 200) {
-        // Keep the response body shape stable for existing TokenRefreshLink/client handling.
+      if (!rotatedToken) {
+        clearRefreshToken(res)
         return res.status(401).send({ ok: false, accessToken: '' })
       }
 
-      const json = await response.json()
-
-      if (!json.access_token || !json.refresh_token) {
-        return res.status(401).send({ ok: false, accessToken: '' })
-      }
-
-      sendRefreshToken(res, json.refresh_token)
-      return res.send({ ok: true, accessToken: json.access_token })
-    } catch {
+      sendRefreshToken(res, rotatedToken.token)
+      sendCsrfToken(res)
+      return res.send({ ok: true, accessToken: createAccessToken(rotatedToken.user) })
+    } catch (err) {
+      logSanitizedError('refresh token rotation failed', err)
+      clearRefreshToken(res)
       return res.status(401).send({ ok: false, accessToken: '' })
     }
   })

--- a/server/src/isAuthMiddleware.ts
+++ b/server/src/isAuthMiddleware.ts
@@ -1,6 +1,7 @@
 import { MyContext } from './MyContext'
 import { MiddlewareFn } from 'type-graphql'
 import { verifyAccessToken } from './auth'
+import { logSanitizedError } from './logger'
 
 export const isAuth: MiddlewareFn<MyContext> = ({ context }, next) => {
   const authorization = context.req.headers.authorization
@@ -13,7 +14,7 @@ export const isAuth: MiddlewareFn<MyContext> = ({ context }, next) => {
     const token = authorization.split(' ')[1]
     context.payload = verifyAccessToken(token)
   } catch (err) {
-    console.error(err)
+    logSanitizedError('access token verification failed', err)
     throw new Error('not authenticated')
   }
 

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,0 +1,8 @@
+export const logSanitizedError = (message: string, err: unknown) => {
+  if (err instanceof Error) {
+    console.error(`${message}: ${err.name}: ${err.message}`)
+    return
+  }
+
+  console.error(`${message}: non-error thrown`)
+}

--- a/server/src/refreshTokenSession.ts
+++ b/server/src/refreshTokenSession.ts
@@ -1,0 +1,128 @@
+import { createHash, randomBytes } from 'crypto'
+import { EntityManager, getManager } from 'typeorm'
+import { createRefreshToken, REFRESH_TOKEN_EXPIRES_IN_MS, verifyRefreshToken } from './auth'
+import { RefreshTokenSession } from './entity/RefreshTokenSession'
+import { User } from './entity/User'
+
+export interface IssuedRefreshToken {
+  token: string
+  session: RefreshTokenSession
+}
+
+export interface RotatedRefreshToken extends IssuedRefreshToken {
+  user: User
+}
+
+const createOpaqueId = () => randomBytes(32).toString('hex')
+
+export const hashRefreshToken = (token: string) => {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+const createExpiresAt = () => new Date(Date.now() + REFRESH_TOKEN_EXPIRES_IN_MS)
+
+const createStoredRefreshToken = async (
+  manager: EntityManager,
+  user: User,
+  tokenFamilyId = createOpaqueId()
+): Promise<IssuedRefreshToken> => {
+  const jti = createOpaqueId()
+  const token = createRefreshToken(user, jti)
+  const session = manager.create(RefreshTokenSession, {
+    userId: user.id,
+    jti,
+    tokenHash: hashRefreshToken(token),
+    tokenFamilyId,
+    revokedAt: null,
+    replacedByTokenId: null,
+    expiresAt: createExpiresAt()
+  })
+
+  await manager.save(session)
+
+  return { token, session }
+}
+
+export const issueRefreshTokenSession = async (user: User): Promise<IssuedRefreshToken> => {
+  return getManager().transaction(manager => createStoredRefreshToken(manager, user))
+}
+
+const revokeTokenFamily = async (manager: EntityManager, tokenFamilyId: string) => {
+  await manager
+    .createQueryBuilder()
+    .update(RefreshTokenSession)
+    .set({ revokedAt: new Date() })
+    .where('"tokenFamilyId" = :tokenFamilyId', { tokenFamilyId })
+    .andWhere('"revokedAt" IS NULL')
+    .execute()
+}
+
+export const revokeAllRefreshTokenSessionsForUser = async (userId: number) => {
+  await getManager()
+    .createQueryBuilder()
+    .update(RefreshTokenSession)
+    .set({ revokedAt: new Date() })
+    .where('"userId" = :userId', { userId })
+    .andWhere('"revokedAt" IS NULL')
+    .execute()
+}
+
+export const revokeRefreshTokenFamilyForToken = async (token: string) => {
+  try {
+    const payload = verifyRefreshToken(token)
+
+    await getManager().transaction(async manager => {
+      const session = await manager.findOne(RefreshTokenSession, { where: { jti: payload.jti } })
+
+      if (session) {
+        await revokeTokenFamily(manager, session.tokenFamilyId)
+      }
+    })
+  } catch {
+    // Invalid or expired tokens have no trusted family to revoke. The cookie will still be cleared.
+  }
+}
+
+export const rotateRefreshToken = async (token: string): Promise<RotatedRefreshToken | null> => {
+  const payload = verifyRefreshToken(token)
+  const tokenHash = hashRefreshToken(token)
+
+  return getManager().transaction(async manager => {
+    const session = await manager.findOne(RefreshTokenSession, {
+      where: { jti: payload.jti },
+      lock: { mode: 'pessimistic_write' }
+    })
+
+    if (!session) {
+      return null
+    }
+
+    if (session.revokedAt) {
+      await revokeTokenFamily(manager, session.tokenFamilyId)
+      return null
+    }
+
+    if (session.tokenHash !== tokenHash || session.userId !== payload.userId || session.expiresAt <= new Date()) {
+      await revokeTokenFamily(manager, session.tokenFamilyId)
+      return null
+    }
+
+    const user = await manager.findOne(User, payload.userId)
+
+    if (!user || user.tokenVersion !== payload.tokenVersion) {
+      await revokeTokenFamily(manager, session.tokenFamilyId)
+      return null
+    }
+
+    const replacement = await createStoredRefreshToken(manager, user, session.tokenFamilyId)
+    session.revokedAt = new Date()
+    session.replacedByTokenId = replacement.session.id
+    await manager.save(session)
+
+    return {
+      token: replacement.token,
+      session: replacement.session,
+      user
+    }
+  })
+}

--- a/server/src/requestSecurity.ts
+++ b/server/src/requestSecurity.ts
@@ -1,0 +1,112 @@
+import { Request } from 'express'
+
+const STATE_CHANGING_METHODS = ['POST', 'PUT', 'DELETE', 'PATCH']
+
+const readBooleanEnv = (name: string): boolean => {
+  const value = process.env[name]
+  return value === '1' || value === 'true' || value === 'yes'
+}
+
+const normalizeOrigin = (origin: string): string => {
+  try {
+    return new URL(origin).origin
+  } catch {
+    return origin
+  }
+}
+
+export const DEFAULT_CLIENT_ORIGIN = normalizeOrigin('http://localhost:3000')
+
+const readConfiguredOrigins = (name: string): string[] => {
+  return (process.env[name] || '')
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean)
+    .map(normalizeOrigin)
+}
+
+export const allowedOrigins = (() => {
+  const origins = readConfiguredOrigins('CORS_ORIGIN')
+  return origins.length > 0 ? origins : [DEFAULT_CLIENT_ORIGIN]
+})()
+
+export const corsOrigin = allowedOrigins.length === 1 ? allowedOrigins[0] : allowedOrigins
+
+const readSingleHeader = (value: string | string[] | undefined): string | undefined => {
+  if (!value || Array.isArray(value)) {
+    return undefined
+  }
+
+  return value
+}
+
+const originFromReferer = (referer: string): string | undefined => {
+  try {
+    return new URL(referer).origin
+  } catch {
+    return undefined
+  }
+}
+
+export const isAllowedOrigin = (origin: string | undefined): boolean => {
+  if (!origin) return false
+  return allowedOrigins.includes(origin)
+}
+
+const getRequestOrigin = (req: Request): string | undefined => {
+  const origin = readSingleHeader(req.headers.origin)
+
+  if (origin) {
+    return origin
+  }
+
+  const referer = readSingleHeader(req.headers.referer)
+  return referer ? originFromReferer(referer) : undefined
+}
+
+const isMissingOriginAllowed = (): boolean => {
+  return process.env.NODE_ENV !== 'production' && readBooleanEnv('ALLOW_MISSING_ORIGIN_IN_DEV')
+}
+
+const isFetchMetadataCrossSiteAllowed = (origin: string | undefined): boolean => {
+  if (!origin) return false
+
+  const whitelist = readConfiguredOrigins('FETCH_METADATA_CROSS_SITE_ALLOW_ORIGINS')
+  return whitelist.includes(origin)
+}
+
+export const validateStateChangingRequestOrigin = (req: Request): string | undefined => {
+  if (
+    Array.isArray(req.headers.origin) ||
+    Array.isArray(req.headers.referer) ||
+    Array.isArray(req.headers['sec-fetch-site'])
+  ) {
+    return 'invalid security header'
+  }
+
+  const secFetchSite = readSingleHeader(req.headers['sec-fetch-site'])
+  const method = req.method.toUpperCase()
+  const requestOrigin = getRequestOrigin(req)
+
+  if (
+    secFetchSite === 'cross-site' &&
+    STATE_CHANGING_METHODS.includes(method) &&
+    !isFetchMetadataCrossSiteAllowed(requestOrigin)
+  ) {
+    return 'cross-site requests are not allowed'
+  }
+
+  const origin = readSingleHeader(req.headers.origin)
+  const referer = readSingleHeader(req.headers.referer)
+
+  if (origin) {
+    return isAllowedOrigin(origin) ? undefined : 'origin is not allowed'
+  }
+
+  if (referer) {
+    const refererOrigin = originFromReferer(referer)
+    return isAllowedOrigin(refererOrigin) ? undefined : 'referer is not allowed'
+  }
+
+  return isMissingOriginAllowed() ? undefined : 'origin or referer is required'
+}

--- a/server/src/sendRefreshToken.ts
+++ b/server/src/sendRefreshToken.ts
@@ -1,8 +1,8 @@
 import { Response } from 'express'
 
-const REFRESH_TOKEN_COOKIE_NAME = 'jid'
-const REFRESH_TOKEN_COOKIE_PATH = '/refresh_token'
-const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000
+export const REFRESH_TOKEN_COOKIE_NAME = '__Host-jid'
+export const REFRESH_TOKEN_COOKIE_PATH = '/'
+export const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000
 
 const refreshTokenCookieBaseOptions = {
   httpOnly: true,

--- a/server/test/requestSecurity.test.ts
+++ b/server/test/requestSecurity.test.ts
@@ -1,0 +1,89 @@
+import { strict as assert } from 'assert'
+import { Request } from 'express'
+
+process.env.CORS_ORIGIN = 'http://localhost:3000,https://app.example.com'
+process.env.NODE_ENV = 'production'
+delete process.env.ALLOW_MISSING_ORIGIN_IN_DEV
+delete process.env.FETCH_METADATA_CROSS_SITE_ALLOW_ORIGINS
+
+const {
+  isAllowedOrigin,
+  validateStateChangingRequestOrigin
+} = require('../src/requestSecurity') as typeof import('../src/requestSecurity')
+
+const request = (headers: Request['headers'], method = 'POST') => ({
+  method,
+  headers
+} as Request)
+
+assert.equal(isAllowedOrigin('http://localhost:3000'), true)
+assert.equal(isAllowedOrigin('https://app.example.com'), true)
+assert.equal(isAllowedOrigin('https://evil.example.com'), false)
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({ origin: 'http://localhost:3000' })),
+  undefined
+)
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({ referer: 'https://app.example.com/account' })),
+  undefined
+)
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({ origin: 'https://evil.example.com' })),
+  'origin is not allowed'
+)
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({ referer: 'not a url' })),
+  'referer is not allowed'
+)
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({})),
+  'origin or referer is required'
+)
+
+process.env.NODE_ENV = 'development'
+process.env.ALLOW_MISSING_ORIGIN_IN_DEV = 'true'
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({})),
+  undefined
+)
+
+process.env.NODE_ENV = 'production'
+process.env.ALLOW_MISSING_ORIGIN_IN_DEV = 'true'
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({})),
+  'origin or referer is required'
+)
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({
+    origin: 'http://localhost:3000',
+    'sec-fetch-site': 'cross-site'
+  })),
+  'cross-site requests are not allowed'
+)
+
+process.env.FETCH_METADATA_CROSS_SITE_ALLOW_ORIGINS = 'http://localhost:3000'
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({
+    origin: 'http://localhost:3000',
+    'sec-fetch-site': 'cross-site'
+  })),
+  undefined
+)
+
+assert.equal(
+  validateStateChangingRequestOrigin(request({
+    origin: ['http://localhost:3000']
+  })),
+  'invalid security header'
+)
+
+console.log('requestSecurity tests passed')

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -72,18 +72,17 @@ const client = new ApolloClient({
       handleFetch: accessToken => {
         setAccessToken(accessToken)
       },
-      handleError: err => {
+      handleError: () => {
         // full control over handling token fetch Error
         console.warn('Your refresh token is invalid. Try to relogin')
-        console.error(err)
       }
     }),
     onError(({ graphQLErrors, networkError }) => {
       if (graphQLErrors) {
-        console.log(graphQLErrors)
+        console.warn(`GraphQL request failed with ${graphQLErrors.length} error(s)`)
       }
       if (networkError) {
-        console.log(networkError)
+        console.warn(`Network request failed: ${networkError.name}`)
       }
     }),
     requestLink,

--- a/web/src/pages/Bye.tsx
+++ b/web/src/pages/Bye.tsx
@@ -11,7 +11,7 @@ export const Bye : React.FC = () => {
   }
 
   if (error) {
-    console.log(error)
+    console.warn(`Bye query failed: ${error.name}`)
     return <div>err</div>
   }
 


### PR DESCRIPTION
## Summary
- replace the external refresh-token proxy with local DB-backed verification and rotation
- add RefreshTokenSession storage, token hashing, family revocation, and reuse detection
- rename the refresh cookie to __Host-jid and tighten /refresh_token origin and Fetch Metadata checks
- add sanitized logging and CSRF-token preparation infrastructure
- add coverage for origin / referer / Fetch Metadata policy checks

## Validation
- cd server && npm test
- cd server && npx tsc --noEmit && npx eslint src --ext .ts
- cd server && npx eslint src test --ext .ts
- cd web && npx tsc --noEmit