### PR TITLE
Remove unused node-fetch server dependency

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,14 +8,6 @@
       "version": "13.1.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
       "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
-    },
-    "@types/node-fetch": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
-      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
-      "requires": {
-        "@types/node": "*"
-      }
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,6 @@
     "typescript": "3.7.4"
   },
   "dependencies": {
-    "@types/node-fetch": "^2.5.4",
     "apollo-server-express": "^2.9.14",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.4",
@@ -30,7 +29,6 @@
     "express": "^4.17.1",
     "graphql": "^14.5.8",
     "jsonwebtoken": "^8.5.1",
-    "node-fetch": "^2.6.0",
     "pg": "^7.3.0",
     "reflect-metadata": "^0.1.10",
     "type-graphql": "^0.17.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,13 +1977,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-fetch@^2.5.4":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.4.tgz#5245b6d8841fc3a6208b82291119bc11c4e0ce44"
-  integrity sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@>=6", "@types/node@^13.1.0":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.0.tgz#225cbaac5fdb2b9ac651b02c070d8aa3c37cc812"
@@ -8803,7 +8796,7 @@ no-case@^2.2.0, no-case@^2.3.2:
   dependencies:
     lower-case "^1.1.1"
 
-node-fetch@2.6.0, node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.6.0:
+node-fetch@2.6.0, node-fetch@^2.1.2, node-fetch@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==


### PR DESCRIPTION
## Summary
- Remove direct server dependencies on `node-fetch` and `@types/node-fetch`
- Update lockfiles while keeping transitive `node-fetch` entries intact

## Validation
- `yarn workspace server test`
- `NODE_OPTIONS=--openssl-legacy-provider yarn workspace web build`

Note: plain `yarn workspace web build` fails under Node 24 with webpack/OpenSSL legacy hashing (`ERR_OSSL_EVP_UNSUPPORTED`), so the build was validated with the OpenSSL legacy provider option.